### PR TITLE
LW-1139 Call REST API for loans instead of X-services.

### DIFF
--- a/src/borrowed.js
+++ b/src/borrowed.js
@@ -1,7 +1,7 @@
 const fetch = require('node-fetch')
 const xml2js = require('xml2js')
 const { t: typy } = require('typy')
-const { mapLoanItems, requestHeaders, isAuthorized } = require('./shared/helpers')
+const { mapLoanItems, requestHeaders, isAuthorized, getAlephUserId } = require('./shared/helpers')
 const { successResponse, errorResponse } = require('./shared/response')
 const { sentryWrapper } = require('./shared/sentryWrapper')
 
@@ -18,7 +18,12 @@ module.exports.handler = sentryWrapper(async (event, context, callback) => {
     }
   }
 
-  const url = `${process.env.ALEPH_URL}/X?op=bor_info&library=${library}&bor_id=${netid}&loans=Y`
+  const alephId = await getAlephUserId(netid, library)
+  if (alephId.error) {
+    return errorResponse(callback, null, alephId.error.status)
+  }
+
+  const url = `${process.env.ALEPH_REST_API_URL}/patron/${alephId}/circulationActions/loans?institution=${library}&view=full`
   const xmlParser = xml2js.Parser({
     tagNameProcessors: [xml2js.processors.stripPrefix],
     attrNameProcessors: [xml2js.processors.stripPrefix],
@@ -46,6 +51,10 @@ module.exports.handler = sentryWrapper(async (event, context, callback) => {
     return errorResponse(callback, null, error.status)
   }
 
-  const items = typy(results, 'bor-info.item-l').safeArray
-  return successResponse(callback, mapLoanItems(items))
+  let loans = []
+  const institutions = typy(results, 'pat-loan-list.loans[0].institution').safeArray
+  institutions.forEach(inst => {
+    loans = loans.concat(typy(inst, 'loan').safeArray)
+  })
+  return successResponse(callback, mapLoanItems(loans))
 })


### PR DESCRIPTION
This change calls a newer Aleph API because it provides the information needed for the "renewable" flag. However, this API doesn't let us query by netid, so we have to look up their aleph id beforehand with another request. This means it will probably be slower, but I didn't see another good solution without having the aleph ID in our Okta tokens. (Which would also require some refactoring of checkout history in addition to any Okta changes.)